### PR TITLE
v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ ada.download('ee9e4ad637b13e729e0d90c09a9b0990', './dist.zip');
 
 ## 版本
 
+### 2.1.1（2020-03-02）
+
+- 修复success的job存在时，取不到最新job的问题
+
 ### 2.1.0（2020-01-17）
 
 - 支持传递stage参数，选择特定的stage来下载artifacts文件

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ ada.download('ee9e4ad637b13e729e0d90c09a9b0990', './dist.zip');
 
 ### 2.1.1（2020-03-02）
 
-- 修复success的job存在时，取不到最新job的问题
+- 修复当多个success状态的job存在时，取不到最新job的问题
 
 ### 2.1.0（2020-01-17）
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,18 +28,18 @@ Ada.prototype.getPipelineId = async function(commitId){
 Ada.prototype.getJobId = async function(pipelineId){
     const token = this._token;
     const projectId = this._projectId;
-    const url = `${this._gitlabUrl}/api/v${this._apiVersion}/projects/${projectId}/pipelines/${pipelineId}/jobs?private_token=${token}`;
+    const url = `${this._gitlabUrl}/api/v${this._apiVersion}/projects/${projectId}/pipelines/${pipelineId}/jobs?private_token=${token}&scope=success`;
     const response = await axios.get(url);
     if(response.status !== 200){
         throw new Error('request error with status code:' + response.status);
     }
-    const successJobs = response.data && response.data.filter((job) => {
-        return job.status === 'success';
-    });
+    const validJobs = response.data && response.data
+        .filter(job => Date.now() < Date.parse(job.artifacts_expire_at).valueOf())
+        .sort((job1, job2) => new Date(job2.finished_at) - new Date(job1.finished_at));
 
-    const job = successJobs.filter(({stage}) => {
+    const job = validJobs.filter(({stage}) => {
         return stage === this._stageName;
-    })[0] || successJobs[0];
+    })[0] || validJobs[0];
 
     if(!job){
         throw new Error('no success build jobs.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@futu/ada",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
### 问题：
- 当同个stage 跑多次job status为success时，目前不会取到最新的zip。

### 场景：

当一个artifacts过期了，再retry生成artifacts时，拉不到最新的。

### 出现原因：

根据pipeline ID拉取job的[api](https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs)，取到的job 时间排序是从前到后的